### PR TITLE
스타일쉐어 테스트 타겟에서의 @testable 을 제거하기 위해 RTMP 관련 프로퍼티들의 접근 제한자를 변경합니다.

### DIFF
--- a/Sources/RTMP/RTMPChunk.swift
+++ b/Sources/RTMP/RTMPChunk.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum RTMPChunkType: UInt8 {
+public enum RTMPChunkType: UInt8 {
     case zero = 0
     case one = 1
     case two = 2
@@ -34,7 +34,7 @@ enum RTMPChunkType: UInt8 {
     }
 }
 
-final class RTMPChunk {
+public final class RTMPChunk {
     enum StreamID: UInt16 {
         case control = 0x02
         case command = 0x03
@@ -42,7 +42,7 @@ final class RTMPChunk {
         case video = 0x05
     }
 
-    static let defaultSize: Int = 128
+    public static let defaultSize: Int = 128
     static let maxTimestamp: UInt32 = 0xFFFFFF
 
     static func getStreamIdSize(_ byte: UInt8) -> Int {
@@ -273,7 +273,7 @@ final class RTMPChunk {
 
 extension RTMPChunk: CustomStringConvertible {
     // MARK: CustomStringConvertible
-    var description: String {
+    public var description: String {
         return Mirror(reflecting: self).description
     }
 }

--- a/Sources/RTMP/RTMPConnection.swift
+++ b/Sources/RTMP/RTMPConnection.swift
@@ -460,7 +460,7 @@ open class RTMPConnection: EventDispatcher {
 
 extension RTMPConnection: RTMPSocketDelegate {
     // MARK: RTMPSocketDelegate
-    func didSetReadyState(_ readyState: RTMPSocketReadyState) {
+    public func didSetReadyState(_ readyState: RTMPSocketReadyState) {
         logger.debug(readyState)
         switch readyState {
         case .handshakeDone:
@@ -484,7 +484,7 @@ extension RTMPConnection: RTMPSocketDelegate {
         }
     }
 
-    func didSetTotalBytesIn(_ totalBytesIn: Int64) {
+    public func didSetTotalBytesIn(_ totalBytesIn: Int64) {
         guard windowSizeS * (sequence + 1) <= totalBytesIn else {
             return
         }
@@ -500,7 +500,7 @@ extension RTMPConnection: RTMPSocketDelegate {
         self.close(isDisconnected: true)
     }
 
-    func listen(_ data: Data) {
+    public func listen(_ data: Data) {
         guard let chunk: RTMPChunk = currentChunk ?? RTMPChunk(data, size: socket.chunkSizeC) else {
             socket.inputBuffer.append(data)
             return

--- a/Sources/RTMP/RTMPConnection.swift
+++ b/Sources/RTMP/RTMPConnection.swift
@@ -193,7 +193,7 @@ open class RTMPConnection: EventDispatcher {
     /// The statistics of outgoing bytes per second.
     @objc open private(set) dynamic var currentBytesOutPerSecond: Int32 = 0
 
-    var socket: RTMPSocketCompatible!
+    open var socket: RTMPSocketCompatible!
     var streams: [UInt32: RTMPStream] = [: ]
     var sequence: Int64 = 0
     var bandWidth: UInt32 = 0

--- a/Sources/RTMP/RTMPSocketCompatible.swift
+++ b/Sources/RTMP/RTMPSocketCompatible.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum RTMPSocketReadyState: UInt8 {
+public enum RTMPSocketReadyState: UInt8 {
     case uninitialized = 0
     case versionSent = 1
     case ackSent = 2
@@ -9,7 +9,7 @@ enum RTMPSocketReadyState: UInt8 {
     case closed = 5
 }
 
-protocol RTMPSocketCompatible: class {
+public protocol RTMPSocketCompatible: class {
     var timeout: Int { get set }
     var delegate: RTMPSocketDelegate? { get set }
     var connected: Bool { get }
@@ -45,7 +45,7 @@ extension RTMPSocketCompatible {
 }
 
 // MARK: -
-protocol RTMPSocketDelegate: IEventDispatcher {
+public protocol RTMPSocketDelegate: IEventDispatcher {
     func listen(_ data: Data)
     func didSetReadyState(_ readyState: RTMPSocketReadyState)
     func didSetTotalBytesIn(_ totalBytesIn: Int64)


### PR DESCRIPTION
## 변경 사항

다음 세 파일의 일부분을 수정했습니다.

- `RTMPChunk`
- `RTMPConnection`
- `RTMPSocketCompatible`

## 리뷰 노트

- 현재 스쉐에서 사용 중인 `0.11.9` 버전을 기반으로 작업했습니다.
- 추후 스타일쉐어에서 HaishinKit 의 버전을 최신화할 때 이와 비슷한 작업을 마찬가지로 해 주어야 합니다.